### PR TITLE
output cleanup for equal and differ

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -134,9 +134,15 @@ func (d *Differ) diff(av, ev reflect.Value) string {
 		if !ev.IsValid() {
 			return "<nil>"
 		}
+		if ev.Kind() == reflect.Ptr {
+			return d.diff(av, ev.Elem())
+		}
 		return d.genDiff("%v", "<nil>", ev.Interface())
 	}
 	if !ev.IsValid() {
+		if av.Kind() == reflect.Ptr {
+			return d.diff(av.Elem(), ev)
+		}
 		return d.genDiff("%v", av.Interface(), "<nil>")
 	}
 

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -62,6 +62,18 @@ func TestDiff(t *testing.T) {
 		}
 	})
 
+	o.Spec("it shows the value of pointers when compared against nil", func(t *testing.T) {
+		a := "foo"
+		out := diff.New().Diff(&a, nil)
+		if !strings.Contains(out, "foo") {
+			t.Fatalf("output %s should have contained actual value '%s'", out, a)
+		}
+		out = diff.New().Diff(nil, &a)
+		if !strings.Contains(out, "foo") {
+			t.Fatalf("output %s should have contained expected value '%s'", out, a)
+		}
+	})
+
 	o.Spec("it can handle nil values", func(t *testing.T) {
 		defer func() {
 			if r := recover(); r != nil {

--- a/matchers/equal.go
+++ b/matchers/equal.go
@@ -27,7 +27,7 @@ func (m EqualMatcher) Match(actual interface{}) (interface{}, error) {
 		if m.differ == nil {
 			return nil, fmt.Errorf("%+v (%[1]T) to equal %+v (%[2]T)", actual, m.expected)
 		}
-		return nil, fmt.Errorf("%v to equal %v\ndiff: %s", actual, m.expected, m.differ.Diff(actual, m.expected))
+		return nil, fmt.Errorf("expected %v to equal %v\ndiff: %s", actual, m.expected, m.differ.Diff(actual, m.expected))
 	}
 
 	return actual, nil

--- a/matchers/equal_test.go
+++ b/matchers/equal_test.go
@@ -41,7 +41,7 @@ func TestEqualDiff(t *testing.T) {
 		t.Fatalf("expected %v to not be nil", err)
 	}
 	expect.Expect(t, mockDiffer).To(pers.HaveMethodExecuted("Diff", pers.WithArgs(103, 101)))
-	format := fmt.Sprintf("103 to equal 101\ndiff: this is a valid diff")
+	format := fmt.Sprintf("expected 103 to equal 101\ndiff: this is a valid diff")
 	if err.Error() != format {
 		t.Fatalf("expected '%v' to match '%v'", err.Error(), format)
 	}


### PR DESCRIPTION
In matchers.Equal: use a full sentence for the comparison.  I believe that the original intent was for
the To type to include the word 'expected', but most matchers don't follow that pattern.  This updates
matchers.Equal to follow the same pattern as the other matchers, where the error message is the full
output for the test.

In differ.Differ.Diff: output the value of a pointer even if it's being compared to nil.  We were pretty
good about checking pointer values if they were being compared to other pointer values, but when comparing
to nil we would end up outputting the address of the non-nil pointer.  This solves that.