### PR TITLE
diff: add a timeout (and options for changing string diff algorithms)

### DIFF
--- a/diff/base_string.go
+++ b/diff/base_string.go
@@ -1,0 +1,53 @@
+package diff
+
+import "github.com/poy/onpar/v2/diff/str"
+
+type baseDiff struct {
+	actual, expected []rune
+
+	sections []str.DiffSection
+	cost     float64
+}
+
+func (d *baseDiff) equal() bool {
+	if len(d.actual) != len(d.expected) {
+		return false
+	}
+	for i, ar := range d.actual {
+		if ar != d.expected[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (d *baseDiff) calculate() {
+	if d.sections != nil {
+		return
+	}
+	d.sections = []str.DiffSection{{Actual: d.actual, Expected: d.expected}}
+	if d.equal() {
+		d.sections[0].Type = str.TypeMatch
+		return
+	}
+	d.sections[0].Type = str.TypeReplace
+	if len(d.actual) > len(d.expected) {
+		d.cost = float64(len(d.actual))
+		return
+	}
+	d.cost = float64(len(d.expected))
+}
+
+func (d *baseDiff) Cost() float64 {
+	d.calculate()
+	return d.cost
+}
+
+func (d *baseDiff) Sections() []str.DiffSection {
+	d.calculate()
+	return d.sections
+}
+
+func baseStringDiff(actual, expected []rune) str.Diff {
+	return &baseDiff{actual: actual, expected: expected}
+}

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -27,7 +27,7 @@ type StringDiffAlgorithm interface {
 	// Once ctx.Done() is closed, diffs will not be read off of the returned
 	// channel - it's up to the algorithm to perform select statements to avoid
 	// deadlocking.
-	Diffs(ctx context.Context, actual, expected []rune) chan str.Diff
+	Diffs(ctx context.Context, actual, expected []rune) <-chan str.Diff
 }
 
 // WithStringAlgos picks the algorithms that will be used to diff strings. We

--- a/diff/helheim_test.go
+++ b/diff/helheim_test.go
@@ -6,9 +6,11 @@
 package diff_test
 
 import (
+	"context"
 	"time"
 
 	"git.sr.ht/~nelsam/hel/v4/vegr"
+	"github.com/poy/onpar/v2/diff/str"
 )
 
 type mockSprinter struct {
@@ -35,5 +37,136 @@ func (m *mockSprinter) Sprint(arg0 ...any) (ret0 string) {
 	m.SprintCalled <- true
 	m.SprintInput.Arg0 <- arg0
 	vegr.PopulateReturns(m.t, "Sprint", m.timeout, m.SprintOutput, &ret0)
+	return ret0
+}
+
+type mockStringDiffAlgorithm struct {
+	t           vegr.T
+	timeout     time.Duration
+	DiffsCalled chan bool
+	DiffsInput  struct {
+		Ctx              chan context.Context
+		Actual, Expected chan []rune
+	}
+	DiffsOutput struct {
+		Ret0 chan chan str.Diff
+	}
+}
+
+func newMockStringDiffAlgorithm(t vegr.T, timeout time.Duration) *mockStringDiffAlgorithm {
+	m := &mockStringDiffAlgorithm{t: t, timeout: timeout}
+	m.DiffsCalled = make(chan bool, 100)
+	m.DiffsInput.Ctx = make(chan context.Context, 100)
+	m.DiffsInput.Actual = make(chan []rune, 100)
+	m.DiffsInput.Expected = make(chan []rune, 100)
+	m.DiffsOutput.Ret0 = make(chan chan str.Diff, 100)
+	return m
+}
+func (m *mockStringDiffAlgorithm) Diffs(ctx context.Context, actual, expected []rune) (ret0 chan str.Diff) {
+	m.t.Helper()
+	m.DiffsCalled <- true
+	m.DiffsInput.Ctx <- ctx
+	m.DiffsInput.Actual <- actual
+	m.DiffsInput.Expected <- expected
+	vegr.PopulateReturns(m.t, "Diffs", m.timeout, m.DiffsOutput, &ret0)
+	return ret0
+}
+
+type mockContext struct {
+	t              vegr.T
+	timeout        time.Duration
+	DeadlineCalled chan bool
+	DeadlineOutput struct {
+		Deadline chan time.Time
+		Ok       chan bool
+	}
+	DoneCalled chan bool
+	DoneOutput struct {
+		Ret0 chan (<-chan struct{})
+	}
+	ErrCalled chan bool
+	ErrOutput struct {
+		Ret0 chan error
+	}
+	ValueCalled chan bool
+	ValueInput  struct {
+		Key chan any
+	}
+	ValueOutput struct {
+		Ret0 chan any
+	}
+}
+
+func newMockContext(t vegr.T, timeout time.Duration) *mockContext {
+	m := &mockContext{t: t, timeout: timeout}
+	m.DeadlineCalled = make(chan bool, 100)
+	m.DeadlineOutput.Deadline = make(chan time.Time, 100)
+	m.DeadlineOutput.Ok = make(chan bool, 100)
+	m.DoneCalled = make(chan bool, 100)
+	m.DoneOutput.Ret0 = make(chan (<-chan struct{}), 100)
+	m.ErrCalled = make(chan bool, 100)
+	m.ErrOutput.Ret0 = make(chan error, 100)
+	m.ValueCalled = make(chan bool, 100)
+	m.ValueInput.Key = make(chan any, 100)
+	m.ValueOutput.Ret0 = make(chan any, 100)
+	return m
+}
+func (m *mockContext) Deadline() (deadline time.Time, ok bool) {
+	m.t.Helper()
+	m.DeadlineCalled <- true
+	vegr.PopulateReturns(m.t, "Deadline", m.timeout, m.DeadlineOutput, &deadline, &ok)
+	return deadline, ok
+}
+func (m *mockContext) Done() (ret0 <-chan struct{}) {
+	m.t.Helper()
+	m.DoneCalled <- true
+	vegr.PopulateReturns(m.t, "Done", m.timeout, m.DoneOutput, &ret0)
+	return ret0
+}
+func (m *mockContext) Err() (ret0 error) {
+	m.t.Helper()
+	m.ErrCalled <- true
+	vegr.PopulateReturns(m.t, "Err", m.timeout, m.ErrOutput, &ret0)
+	return ret0
+}
+func (m *mockContext) Value(key any) (ret0 any) {
+	m.t.Helper()
+	m.ValueCalled <- true
+	m.ValueInput.Key <- key
+	vegr.PopulateReturns(m.t, "Value", m.timeout, m.ValueOutput, &ret0)
+	return ret0
+}
+
+type mockDiff struct {
+	t          vegr.T
+	timeout    time.Duration
+	CostCalled chan bool
+	CostOutput struct {
+		Ret0 chan float64
+	}
+	SectionsCalled chan bool
+	SectionsOutput struct {
+		Ret0 chan []str.DiffSection
+	}
+}
+
+func newMockDiff(t vegr.T, timeout time.Duration) *mockDiff {
+	m := &mockDiff{t: t, timeout: timeout}
+	m.CostCalled = make(chan bool, 100)
+	m.CostOutput.Ret0 = make(chan float64, 100)
+	m.SectionsCalled = make(chan bool, 100)
+	m.SectionsOutput.Ret0 = make(chan []str.DiffSection, 100)
+	return m
+}
+func (m *mockDiff) Cost() (ret0 float64) {
+	m.t.Helper()
+	m.CostCalled <- true
+	vegr.PopulateReturns(m.t, "Cost", m.timeout, m.CostOutput, &ret0)
+	return ret0
+}
+func (m *mockDiff) Sections() (ret0 []str.DiffSection) {
+	m.t.Helper()
+	m.SectionsCalled <- true
+	vegr.PopulateReturns(m.t, "Sections", m.timeout, m.SectionsOutput, &ret0)
 	return ret0
 }

--- a/diff/str/char.go
+++ b/diff/str/char.go
@@ -1,0 +1,294 @@
+package str
+
+import (
+	"context"
+	"sync"
+)
+
+func greaterBaseCost(a, b []rune) float64 {
+	if len(a) > len(b) {
+		return float64(len(a))
+	}
+	return float64(len(b))
+}
+
+type charDiff struct {
+	baseCost    float64
+	perCharCost float64
+
+	cost     float64
+	sections []DiffSection
+}
+
+func (d *charDiff) calculate() {
+	d.cost = 0
+	for _, s := range d.sections {
+		if s.Type == TypeMatch {
+			continue
+		}
+		d.cost += d.baseCost + d.perCharCost*greaterBaseCost(s.Actual, s.Expected)
+	}
+}
+
+func (d *charDiff) Cost() float64 {
+	return d.cost
+}
+
+func (d *charDiff) Sections() []DiffSection {
+	return d.sections
+}
+
+// broadcast is a type which can broadcast new diffs to multiple subscribers.
+type broadcast struct {
+	mu sync.Mutex
+
+	closed bool
+	curr   Diff
+	subs   []chan Diff
+}
+
+// subscribe subscribes to an existing broadcast, returning a channel to listen
+// for changes on. The current value will be sent on the channel immediately.
+func (b *broadcast) subscribe() chan Diff {
+	ch := make(chan Diff, 1)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.subs = append(b.subs, ch)
+
+	if b.curr != nil {
+		ch <- b.curr
+	}
+	if b.closed {
+		close(ch)
+	}
+	return ch
+}
+
+// send sends d to all subscribers and updates the current value for new
+// subscribers.
+func (b *broadcast) send(ctx context.Context, d Diff) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.curr = d
+
+	for _, s := range b.subs {
+		select {
+		case s <- d:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// done signals that b has exhausted all possibilities and all subscribers
+// should be closed.
+func (b *broadcast) done() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.closed = true
+	for _, s := range b.subs {
+		close(s)
+	}
+}
+
+type diffIdx struct {
+	aStart, eStart int
+}
+
+// CharDiffOpt is an option function for changing the behavior of the
+// NewCharDiff constructor.
+type CharDiffOpt func(CharDiff) CharDiff
+
+// CharDiffBaseCost is a CharDiff option to set the base cost per diff section.
+// Increasing this will reduce the number of diff sections in the output at the
+// cost of larger diff sections.
+//
+// Default is 0.
+func CharDiffBaseCost(cost float64) CharDiffOpt {
+	return func(d CharDiff) CharDiff {
+		d.baseCost = cost
+		return d
+	}
+}
+
+// CharDiffPerCharCost is a CharDiff option to set the cost-per-character of any
+// differences returned. Increasing this cost will reduce the size of diff
+// sections at the cost of more diff sections.
+//
+// Default is 1
+func CharDiffPerCharCost(cost float64) CharDiffOpt {
+	return func(d CharDiff) CharDiff {
+		d.perCharCost = cost
+		return d
+	}
+}
+
+// CharDiff is a per-character diff algorithm, meaning that it makes no distinctions
+// about word or line boundaries when generating a diff.
+type CharDiff struct {
+	baseCost    float64
+	perCharCost float64
+}
+
+func NewCharDiff(opts ...CharDiffOpt) *CharDiff {
+	d := CharDiff{
+		baseCost:    0,
+		perCharCost: 1,
+	}
+	for _, o := range opts {
+		d = o(d)
+	}
+	return &d
+}
+
+func (c *CharDiff) Diffs(ctx context.Context, actual, expected []rune) chan Diff {
+	ch := make(chan Diff)
+	var m sync.Map
+	go c.sendDiffs(ctx, ch, &m, actual, expected, 0, 0)
+	return ch
+}
+
+func (c *CharDiff) sendDiffs(ctx context.Context, ch chan<- Diff, cache *sync.Map, actual, expected []rune, actualStart, expectedStart int) {
+	actualEnd, expectedEnd := actualStart, expectedStart
+	for actualEnd < len(actual) && expectedEnd < len(expected) && actual[actualEnd] == expected[expectedEnd] {
+		actualEnd++
+		expectedEnd++
+	}
+	if actualEnd == len(actual) && expectedEnd == len(expected) {
+		if actualEnd-actualStart > 0 || expectedEnd-expectedStart > 0 {
+			diff := &charDiff{
+				baseCost:    c.baseCost,
+				perCharCost: c.perCharCost,
+				sections:    []DiffSection{{Type: TypeMatch, Actual: actual[actualStart:actualEnd], Expected: expected[expectedStart:expectedEnd]}},
+			}
+			select {
+			case ch <- diff:
+			case <-ctx.Done():
+				close(ch)
+				return
+			}
+		}
+		close(ch)
+		return
+	}
+	bcast := &broadcast{}
+	cached, running := cache.LoadOrStore(diffIdx{aStart: actualEnd, eStart: expectedEnd}, bcast)
+	bcast = cached.(*broadcast)
+
+	var baseSections []DiffSection
+	if actualEnd-actualStart > 0 || expectedEnd-expectedStart > 0 {
+		baseSections = []DiffSection{
+			{Type: TypeMatch, Actual: actual[actualStart:actualEnd], Expected: expected[expectedStart:expectedEnd]},
+		}
+	}
+	go func() {
+		defer close(ch)
+		subCh := bcast.subscribe()
+		var cheapest *charDiff
+		for {
+			select {
+			case subDiff, ok := <-subCh:
+				if !ok {
+					return
+				}
+				diff := &charDiff{
+					baseCost:    c.baseCost,
+					perCharCost: c.perCharCost,
+					sections:    append([]DiffSection(nil), baseSections...),
+				}
+				diff.sections = append(diff.sections, subDiff.Sections()...)
+				diff.calculate()
+				if cheapest == nil || cheapest.Cost() > diff.Cost() {
+					cheapest = diff
+					select {
+					case ch <- diff:
+					case <-ctx.Done():
+						return
+					}
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	if !running {
+		subCh := make(chan Diff)
+		var wg sync.WaitGroup
+
+		go func() {
+			defer bcast.done()
+
+			base := &charDiff{
+				baseCost:    c.baseCost,
+				perCharCost: c.perCharCost,
+				sections: []DiffSection{
+					{Type: TypeReplace, Actual: actual[actualEnd:], Expected: expected[expectedEnd:]},
+				},
+			}
+			base.calculate()
+			shortest := Diff(base)
+			bcast.send(ctx, shortest)
+			if ctx.Err() != nil {
+				return
+			}
+
+			for diff := range subCh {
+				if ctx.Err() != nil {
+					return
+				}
+				if diff.Cost() >= shortest.Cost() {
+					continue
+				}
+				shortest = diff
+				bcast.send(ctx, shortest)
+			}
+		}()
+
+		for i := actualEnd; i < len(actual); i++ {
+			for j := expectedEnd; j < len(expected); j++ {
+				if ctx.Err() != nil {
+					return
+				}
+				if actual[i] != expected[j] {
+					continue
+				}
+				subSubCh := make(chan Diff)
+				wg.Add(1)
+				go func(i, j int) {
+					defer wg.Done()
+					for {
+						select {
+						case subDiff, ok := <-subSubCh:
+							if !ok {
+								return
+							}
+							diff := &charDiff{
+								baseCost:    c.baseCost,
+								perCharCost: c.perCharCost,
+								sections: []DiffSection{
+									{Type: TypeReplace, Actual: actual[actualEnd:i], Expected: expected[expectedEnd:j]},
+								},
+							}
+							diff.sections = append(diff.sections, subDiff.Sections()...)
+							diff.calculate()
+							select {
+							case subCh <- diff:
+							case <-ctx.Done():
+								return
+							}
+						case <-ctx.Done():
+							return
+						}
+					}
+				}(i, j)
+				c.sendDiffs(ctx, subSubCh, cache, actual, expected, i, j)
+			}
+		}
+
+		go func() {
+			defer close(subCh)
+			wg.Wait()
+		}()
+	}
+}

--- a/diff/str/char_test.go
+++ b/diff/str/char_test.go
@@ -1,0 +1,201 @@
+package str_test
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/poy/onpar/v2"
+	"github.com/poy/onpar/v2/diff/str"
+	"github.com/poy/onpar/v2/expect"
+	"github.com/poy/onpar/v2/matchers"
+)
+
+func TestCharDiff(t *testing.T) {
+	o := onpar.New(t)
+
+	matchReplace := func(t *testing.T, start str.Type, l ...string) []str.DiffSection {
+		// matchReplace is used to generate match/replace cadence for expected
+		// values, since by default the char diff will always return diffs that
+		// have a match followed by a replace followed by a match, and so on.
+
+		t.Helper()
+
+		var sections []str.DiffSection
+		curr := start
+		for _, v := range l {
+			section := str.DiffSection{
+				Type:     curr,
+				Actual:   []rune(v),
+				Expected: []rune(v),
+			}
+			if curr == str.TypeReplace {
+				// NOTE: if any of the diffs we need to test contain a pipe
+				// character, this will break.
+				parts := strings.Split(v, "|")
+				if len(parts) != 2 {
+					t.Fatalf("test error: expected replace string (%v) to use a | character to separate actual and expected values, but got %d values when splitting", v, len(parts))
+				}
+				section.Actual = []rune(parts[0])
+				section.Expected = []rune(parts[1])
+			}
+			sections = append(sections, section)
+			curr = 1 - curr
+		}
+		return sections
+	}
+
+	replace := func(t *testing.T, a, b string) string {
+		// replace is used to generate replacement strings for the matchReplace
+		// function. This helps make the test read more clearly, while also
+		// checking for separator characters in the source strings.
+		t.Helper()
+
+		if strings.Contains(a, "|") {
+			t.Fatalf("replace source string %v contains pipe character", a)
+		}
+		if strings.Contains(b, "|") {
+			t.Fatalf("replace source string %v contains pipe character", b)
+		}
+		return fmt.Sprintf("%s|%s", a, b)
+	}
+
+	o.Group("exhaustive results", func() {
+		finalDiff := func(t *testing.T, timeout time.Duration, diffs chan str.Diff) str.Diff {
+			t.Helper()
+
+			var final str.Diff
+			tCh := time.After(timeout)
+			for {
+				select {
+				case next, ok := <-diffs:
+					if !ok {
+						return final
+					}
+					final = next
+				case <-tCh:
+					t.Fatalf("failed to exhaust results within %v", timeout)
+				}
+			}
+		}
+
+		for _, tt := range []struct {
+			name             string
+			actual, expected string
+			output           []str.DiffSection
+		}{
+			{"different strings", "foo", "bar", []str.DiffSection{{Type: str.TypeReplace, Actual: []rune("foo"), Expected: []rune("bar")}}},
+			{"different substrings", "foobarbaz", "fooeggbaz", matchReplace(t, str.TypeMatch, "foo", replace(t, "bar", "egg"), "baz")},
+			{"longer expected string", "foobarbaz", "foobazingabaz", matchReplace(t, str.TypeMatch, "fooba", replace(t, "r", "zinga"), "baz")},
+			{"longer actual string", "foobazingabaz", "foobarbaz", matchReplace(t, str.TypeMatch, "fooba", replace(t, "zinga", "r"), "baz")},
+			{"multiple different substrings", "pythonfooeggsbazingabacon", "gofoobarbazingabaz",
+				matchReplace(t, str.TypeReplace,
+					replace(t, "pyth", "g"),
+					"o",
+					replace(t, "n", ""),
+					"foo",
+					replace(t, "eggs", "bar"),
+					"bazingaba",
+					replace(t, "con", "z"),
+				),
+			},
+		} {
+			tt := tt
+			o.Spec(tt.name, func(t *testing.T) {
+				ch := str.NewCharDiff().Diffs(context.Background(), []rune(tt.actual), []rune(tt.expected))
+				final := finalDiff(t, time.Second, ch)
+
+				exp := readableSections(tt.output)
+				for i, v := range readableSections(final.Sections()) {
+					// NOTE: these matches will be checked again below;
+					// this is just to provide more detail about which
+					// indexes failed. We could use a differ, but since
+					// this test is testing differs, a bug in the differ
+					// might break the test (rather than simply failing
+					// it).
+					if i > len(exp) {
+						t.Errorf("actual (length %d) was longer than expected (length %d)", len(final.Sections()), len(exp))
+						break
+					}
+					if !reflect.DeepEqual(v, exp[i]) {
+						t.Errorf("%#v did not match %#v", v, exp[i])
+					}
+				}
+				expect.Expect(t, readableSections(final.Sections())).To(matchers.Equal(readableSections(tt.output)))
+			})
+		}
+
+		o.Spec("it doesn't hang on strings mentioned in issue 30", func(t *testing.T) {
+			// This diff has multiple options for the "best" result (more than
+			// one diff at the lowest possible cost). So we can't very well
+			// assert on the exact diff returned, but we can assert on the cost
+			// and the total actual and expected strings.
+			actual := `{"current":[{"kind":0,"at":{"seconds":1596288863,"nanos":13000000},"msg":"Something bad happened."}]}`
+			expected := `{"current": [{"kind": "GENERIC", "at": "2020-08-01T13:34:23.013Z", "msg": "Something bad happened."}], "history": []}`
+			diffs := str.NewCharDiff().Diffs(context.Background(), []rune(actual), []rune(expected))
+			final := finalDiff(t, time.Second, diffs)
+
+			expectedCost := float64(57)
+			expect.Expect(t, final.Cost()).To(matchers.Equal(expectedCost))
+
+			var retActual, retExpected string
+			for _, v := range final.Sections() {
+				retActual += string(v.Actual)
+				retExpected += string(v.Expected)
+			}
+			expect.Expect(t, retActual).To(matchers.Equal(actual))
+			expect.Expect(t, retExpected).To(matchers.Equal(expected))
+		})
+	})
+
+	o.Spec("it returns decreasingly costly results until the context is done", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		actual := "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua"
+		expected := "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+		diffs := str.NewCharDiff().Diffs(ctx, []rune(actual), []rune(expected))
+
+		// We want to check a few results, ensuring that the cost is lower each
+		// time, before cancelling the context to ensure that the results stop
+		// when the context finishes.
+		const toCheck = 5
+		best := math.MaxFloat64
+		for i := 0; i < toCheck; i++ {
+			v := <-diffs
+			if v.Cost() > best {
+				t.Fatalf("new cost (%f) is greater than old cost (%f)", v.Cost(), best)
+			}
+			best = v.Cost()
+		}
+
+		cancel()
+		// Ensure that the logic has time to shut down before we resume reading
+		// from the channel.
+		time.Sleep(100 * time.Millisecond)
+		if _, ok := <-diffs; ok {
+			t.Fatalf("results channel is still open after cancelling the context")
+		}
+	})
+}
+
+type readableSection struct {
+	typ              str.Type
+	actual, expected string
+}
+
+func readableSections(s []str.DiffSection) []readableSection {
+	var rs []readableSection
+	for _, v := range s {
+		rs = append(rs, readableSection{
+			typ:      v.Type,
+			actual:   string(v.Actual),
+			expected: string(v.Expected),
+		})
+	}
+	return rs
+}

--- a/diff/str/char_test.go
+++ b/diff/str/char_test.go
@@ -65,7 +65,7 @@ func TestCharDiff(t *testing.T) {
 	}
 
 	o.Group("exhaustive results", func() {
-		finalDiff := func(t *testing.T, timeout time.Duration, diffs chan str.Diff) str.Diff {
+		finalDiff := func(t *testing.T, timeout time.Duration, diffs <-chan str.Diff) str.Diff {
 			t.Helper()
 
 			var final str.Diff

--- a/diff/str/diff.go
+++ b/diff/str/diff.go
@@ -1,0 +1,31 @@
+package str
+
+type Type int
+
+const (
+	TypeMatch = iota
+	TypeReplace
+)
+
+// DiffSection represents a single chunk of a diff.
+type DiffSection struct {
+	Type             Type
+	Actual, Expected []rune
+}
+
+// Diff represents a full diff of two values.
+type Diff interface {
+	// Cost is the calculated cost of changing from one value to another.
+	// Basically, if provided with multiple diffs, the Differ will always prefer
+	// the lowest cost.
+	//
+	// Generally, a cost of 0 should represent exactly equal values, so negative
+	// numbers shouldn't usually be used. However, if they are used, they will
+	// work the same as positive values, being preferred over any value higher
+	// than them.
+	Cost() float64
+
+	// Sections returns all of the sections of the diff. This will be used to
+	// generate output, depending on the diff formats being used.
+	Sections() []DiffSection
+}


### PR DESCRIPTION
I've run into occasional edge cases where diffs take a very long time (sometimes indefinite).  This _always_ occurs with string diffs.  It's not really any surprise (string diffs are hard), but it's not a fun time when it happens - often you have to disable the diffs across the whole project to get the results from the failing test.

This PR adds a timeout option (default: 1 second) and updates the string diffing logic to return incrementally better diffs on a channel so that we can return the best diff we've found when the time is up.

As sort of a (useful?) side effect, this allows the caller to configure the string diff algorithms they want to use.  On this pass, I didn't try to make any changes to the default algorithm or improve anything else about the diffing logic - the logic is kept as-is but moved to a separate type (and package), and rewritten to return its results on a channel.  However, I am certain that this diffing logic will not work for all strings - sometimes a line-based diffing algorithm would be better, or other times a word-based differ is the ideal.  So I decided that allowing users to choose the string diff algorithms they want to use is beneficial enough to expose it as a constructor option.