### PR TITLE
before/after each: solve data race

### DIFF
--- a/onpar_test.go
+++ b/onpar_test.go
@@ -77,7 +77,7 @@ func TestNewWithBeforeEach(t *testing.T) {
 	t.Run("FakeSpecs", func(t *testing.T) {
 		o := onpar.New(t)
 
-		o.Spec("it runs a spec without a beforeeach", func(*testing.T) {
+		o.SerialSpec("it runs a spec without a beforeeach", func(*testing.T) {
 			c <- "A"
 		})
 
@@ -86,7 +86,7 @@ func TestNewWithBeforeEach(t *testing.T) {
 			return "foo"
 		})
 
-		b.Spec("it runs a spec on a BeforeEach", func(string) {
+		b.SerialSpec("it runs a spec on a BeforeEach", func(string) {
 			c <- "B"
 		})
 	})


### PR DESCRIPTION
BeforeEach and AfterEach in the new generics-aware onpar ended up sharing memory between tests in some scenarios. This resulted in data races, specifically when it came to passing the correct value to the AfterEach.

Now each spec gets its own scope which tracks variables just for that spec.