### PR TITLE
add a TableSpec function to help with table testing

### DIFF
--- a/onpar.go
+++ b/onpar.go
@@ -25,6 +25,40 @@ type child interface {
 	addSpecs()
 }
 
+// Table is an entry to be used in table tests.
+type Table[T, U, V any] struct {
+	parent *Onpar[T, U]
+	spec   func(U, V)
+}
+
+// TableSpec returns a Table type which may be used to declare table tests. The
+// spec argument is the test that will be run for each entry in the table.
+//
+// This is effectively syntactic sugar for looping over table tests and calling
+// `parent.Spec` for each entry in the table.
+func TableSpec[T, U, V any](parent *Onpar[T, U], spec func(U, V)) Table[T, U, V] {
+	return Table[T, U, V]{parent: parent, spec: spec}
+}
+
+// Entry adds an entry to t using entry as the value for this table entry.
+func (t Table[T, U, V]) Entry(name string, entry V) Table[T, U, V] {
+	t.parent.Spec(name, func(v U) {
+		t.spec(v, entry)
+	})
+	return t
+}
+
+// FnEntry adds an entry to t that calls setup in order to get its entry value.
+// The value from the BeforeEach will be passed to setup, and then both values
+// will be passed to the table spec.
+func (t Table[T, U, V]) FnEntry(name string, setup func(U) V) Table[T, U, V] {
+	t.parent.Spec(name, func(v U) {
+		entry := setup(v)
+		t.spec(v, entry)
+	})
+	return t
+}
+
 // Onpar stores the state of the specs and groups
 type Onpar[T, U any] struct {
 	t TestRunner

--- a/onpar_test.go
+++ b/onpar_test.go
@@ -36,7 +36,7 @@ func TestSingleNestedSpec(t *testing.T) {
 	objs := chanToSlice(c)
 
 	if len(objs) != 4 {
-		t.Fatalf("expected objs (len=%d) to have len %d", len(objs), 3)
+		t.Fatalf("expected objs (len=%d) to have len %d", len(objs), 4)
 	}
 
 	objA := findSpec(objs, "DA-A")

--- a/tabular_test.go
+++ b/tabular_test.go
@@ -1,0 +1,153 @@
+package onpar_test
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/poy/onpar"
+)
+
+func TestTableSpec_Entry(t *testing.T) {
+	t.Parallel()
+	c := createTableScaffolding(t)
+
+	objs := chanToSlice(c)
+
+	if len(objs) != 2 {
+		t.Fatalf("expected objs (len=%d) to have len %d", len(objs), 2)
+	}
+
+	objA := findSpec(objs, "DA-A")
+	if objA == nil {
+		t.Fatal("unable to find spec A")
+	}
+
+	if len(objA.c) != 3 {
+		t.Fatalf("expected objs (len=%d) to have len %d", len(objA.c), 3)
+	}
+
+	if !reflect.DeepEqual(objA.c, []string{"-BeforeEach", "DA-A", "-AfterEach"}) {
+		t.Fatalf("invalid call order for spec A: %v", objA.c)
+	}
+}
+
+func ExampleTable_Entry() {
+	var t *testing.T
+	o := onpar.New(t)
+	defer o.Run()
+
+	type table struct {
+		input          string
+		expectedOutput string
+	}
+	f := func(in string) string {
+		return in + "world"
+	}
+	onpar.TableSpec(o, func(t *testing.T, tt table) {
+		output := f(tt.input)
+		if output != tt.expectedOutput {
+			t.Fatalf("expected %v to produce %v; got %v", tt.input, tt.expectedOutput, output)
+		}
+	}).
+		Entry("simple output", table{"hello", "helloworld"}).
+		Entry("with a space", table{"hello ", "hello world"}).
+		Entry("and a comma", table{"hello, ", "hello, world"})
+}
+
+func TestTableSpec_FnEntry(t *testing.T) {
+	t.Parallel()
+	c := createTableScaffolding(t)
+
+	objs := chanToSlice(c)
+
+	if len(objs) != 2 {
+		t.Fatalf("expected objs (len=%d) to have len %d", len(objs), 2)
+	}
+
+	objB := findSpec(objs, "DA-B")
+	if objB == nil {
+		t.Fatal("unable to find spec B")
+	}
+
+	if len(objB.c) != 4 {
+		t.Fatalf("expected objs (len=%d) to have len %d", len(objB.c), 4)
+	}
+
+	if !reflect.DeepEqual(objB.c, []string{"-BeforeEach", "-TableEntrySetup", "DA-B", "-AfterEach"}) {
+		t.Fatalf("invalid call order for spec A: %v", objB.c)
+	}
+}
+
+func ExampleTable_FnEntry() {
+	var t *testing.T
+	o := onpar.New(t)
+	defer o.Run()
+
+	type table struct {
+		input          string
+		expectedOutput string
+	}
+	f := func(in string) string {
+		return in + "world"
+	}
+	onpar.TableSpec(o, func(t *testing.T, tt table) {
+		output := f(tt.input)
+		if output != tt.expectedOutput {
+			t.Fatalf("expected %v to produce %v; got %v", tt.input, tt.expectedOutput, output)
+		}
+	}).
+		FnEntry("simple output", func(t *testing.T) table {
+			var buf bytes.Buffer
+			if _, err := buf.WriteString("hello"); err != nil {
+				t.Fatalf("expected buffer write to succeed; got %v", err)
+			}
+			return table{input: buf.String(), expectedOutput: "helloworld"}
+		})
+}
+
+func createTableScaffolding(t *testing.T) <-chan *testObject {
+	objs := make(chan *testObject, 100)
+
+	t.Run("FakeSpecs", func(t *testing.T) {
+		o := onpar.BeforeEach(onpar.New(t), func(t *testing.T) *mockTest {
+			obj := NewTestObject()
+			obj.Use("-BeforeEach")
+
+			objs <- obj
+
+			return &mockTest{t, 99, "something", obj}
+		})
+		defer o.Run()
+
+		o.AfterEach(func(tt *mockTest) {
+			tt.o.Use("-AfterEach")
+		})
+
+		type table struct {
+			name     string
+			expected mockTest
+		}
+
+		onpar.TableSpec(o, func(tt *mockTest, tab table) {
+			if tt.i != tab.expected.i {
+				tt.t.Fatalf("expected %d = %d", tt.i, tab.expected.i)
+			}
+
+			if tt.s != tab.expected.s {
+				tt.t.Fatalf("expected %s = %s", tt.s, tab.expected.s)
+			}
+
+			tt.o.Use(tab.name)
+		}).
+			Entry("DA-A", table{name: "DA-A", expected: mockTest{i: 99, s: "something"}}).
+			FnEntry("DA-B", func(tt *mockTest) table {
+				tt.i = 21
+				tt.s = "foo"
+				tt.o.Use("-TableEntrySetup")
+				return table{name: "DA-B", expected: mockTest{i: 21, s: "foo"}}
+			})
+	})
+
+	return objs
+}


### PR DESCRIPTION
Long story short: I often find myself doing the following:

```go
for _, tt := range tests {
    tt := tt // this is very easy to forget
    o.Spec(tt.name, func(tc testCtx) {
        // do some work
        tc.expect(foo).To(equal(tt.expected))
    })
}
```

---

This PR adds the concept of table-driven tests to onpar as a first-class feature, so that we can instead do:

```go
onpar.TableSpec(o, func(tc testCtx, tt tableTest) {
    // do some work
    tc.expect(foo).To(equal(tt.expected))
}).
    Entry(name1, tableTest{...}).
    Entry(name2, tableTest{...})
```

This has one big advantage: you don't have to remember `tt := tt`.

It also allows us to keep the spec name out of the table struct - not critically important, but it has always felt a little dirty to me that the spec always has access to its name in table tests. I am always tempted to adjust spec logic based on the test's name.

---

The other advantage is that entries may be defined with functions instead of concrete structs, e.g.

```go
onpar.TableSpec(o, func(tc testCtx, tt tableTest) {
    // do some work
    tc.expect(foo).To(equal(tt.expected))
}).
    Entry(name1, tableTest{...}).
    FnEntry(name2, func(tc testCtx) tableTest {
        // set up tt using tc
        return tt
    }).
```

This allows us to put more of the setup logic in each specific test case, rather than performing setup as part of the spec, which (ideally) helps narrow down failures when they happen in the setup logic.